### PR TITLE
GitHub Action for building `WebRTC.xcframework`

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,0 +1,35 @@
+name: WebRTC Build And Upload
+on: 
+  workflow_dispatch:
+    inputs:
+      webrtc_version:
+        description: 'WebRTC Version'
+        required: true
+        type: string
+      build_number:
+        description: 'Build Number'
+        required: true
+        type: string
+        default: '0'
+jobs:
+  build:
+    name: Build WebRTC
+    runs-on: macos-15
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Run build script
+        run: |
+          export PATH="$PATH:$(pwd)/depot_tools"
+          npx zx ./scripts/webrtc-build.mjs -v ${{ inputs.webrtc_version }} -n ${{ inputs.build_number }}
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            build/WebRTC.xcframework/
+            build/version.json

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,4 +1,4 @@
-name: WebRTC Build And Upload
+name: WebRTC Build and Upload
 on: 
   workflow_dispatch:
     inputs:
@@ -12,8 +12,8 @@ on:
         type: string
         default: '0'
 jobs:
-  build:
-    name: Build WebRTC
+  build_and_upload:
+    name: Build and Upload
     runs-on: macos-15
     timeout-minutes: 90
     permissions:


### PR DESCRIPTION
## Description

 Added a GitHub action to remotely build `WebRTC.xcframework`.

This action requires two inputs of `WebRTC Version` and `Build Number`, and uploads `WebRTC.xcframework` and `version.json` as output.

## How to test

Temporarily changed the default branch and ran this action manually to make sure it was working as expected.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/14565970819