### PR TITLE
Pinning versions of third-party actions using commit hashes

### DIFF
--- a/.github/workflows/build-and-pr.yml
+++ b/.github/workflows/build-and-pr.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Run build script

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Run build script
@@ -28,7 +28,7 @@ jobs:
           export PATH="$PATH:$(pwd)/depot_tools"
           npx zx ./scripts/webrtc-build.mjs -v ${{ inputs.webrtc_version }} -n ${{ inputs.build_number }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: |
             build/WebRTC.xcframework/


### PR DESCRIPTION
## Description

Using commit hash to specify versions of third-party actions for security improvements.

See also [Security hardening for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [Automated Dependency Updates for GitHub Actions - Renovate Docs](https://docs.renovatebot.com/modules/manager/github-actions/#additional-information)

## How to test

Test run on `pin-gha-versions` branch.
https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/14699072445