### PR TITLE
Output `branch_head_number` to `version.json`

### DIFF
--- a/scripts/webrtc-build.mjs
+++ b/scripts/webrtc-build.mjs
@@ -38,7 +38,7 @@ if (!response_milestones.ok) {
 }
 
 const milestone = await response_milestones.json()
-const branch_head_number = milestone[0].webrtc_branch
+const branch_head_number = Number(milestone[0].webrtc_branch)
 
 echo`✅ Use branch_head/${branch_head_number}.`
 
@@ -203,6 +203,7 @@ const version_json = {
   "version": {
     "full": `${webrtc_version}.${commit_position}.${build_number}`,
     "webrtc_version": webrtc_version,
+    "branch_head_number": branch_head_number,
     "commit_position": commit_position,
     "build_number": build_number
   },


### PR DESCRIPTION
## Description

Have the build script `webrtc-build.mjs` export `version.json` with `branch_head_number` field.

This will be a preparation for the following flow.

1. Build `WebRTC.xcframework` with version.json
2. Create a release automatically when tag push
3. Fill in the release notes based on `version.json` information

## How to test

1. Run `WebRTC Build and Upload` on `output-branch-head-number` branch
    - https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/14699723352
1. Download the artifact and extract `version.json`
1. Verify that it is as expected