### PR TITLE
Fix issues in `Create Release` action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,12 +37,16 @@ jobs:
 
           PREV_RELEASE=$(gh release list --limit 1 --json tagName | jq -r '.[].tagName')
           MERGE_COMMITS=$(git log ${PREV_RELEASE}...${NEXT_RELEASE} --merges --oneline | awk '{print $1}' | xargs)
-          PR_URL_PREFIX="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull"
-          PR_LIST=$(
+          if [ -n "$MERGE_COMMITS" ]; then
+            PR_URL_PREFIX="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull"
+            PR_LIST_MD=$(
               gh pr list --state merged --search "${MERGE_COMMITS}" --json number,title | \
               jq -r '.[] | [.number, .title] | join("\t")' | \
               awk -v FS="\t" '{if ($2 !~ /^WebRTC [0-9]+\.[0-9]+\.[0-9]+$/) { printf "- %s [#%s]('$PR_URL_PREFIX'/%s)\n", $2, $1, $1 }}'
-          )
+            )
+          else
+            PR_LIST_MD="Nothing"
+          fi
 
           NOTES=$(cat <<- EOS
           ## Build


### PR DESCRIPTION
## Description

Fix some issues in the [Create Release](https://github.com/SafiePublic/safie-webrtc-ios-build/actions/workflows/create-release.yml) action added #13 

This action has following problems.

- Not set `GH_TOKEN` environment variable when using `gh` command
- If merged PRs not existed, `Development` section will broken

These are detected by this test run:
https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/15727620864/job/44320971240