### PR TITLE
Fix a remaining issue in `Create Release` action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-tags: true
       - name: Set GITHUB_ENV
         run: |
           NEXT_RELEASE=${{ github.ref_name }}


### PR DESCRIPTION
## Description

`Create Release` action has some problems and fixed by #14.

However, this fix still leaves a following issue.

> fatal: ambiguous argument '134.1.0...135.3.0': unknown revision or path not in the working tree.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/15728877133/job/44325058755

To fix this remaining bug, added an option `fetch-tags: true` to [actions/checkout](https://github.com/actions/checkout).