### PR TITLE
Fetch remote tags as a step of `Create Release` action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,6 +29,11 @@ jobs:
           echo "COMMIT_POSITION=$COMMIT_POSITION" >> $GITHUB_ENV
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
           echo "PR_LIST_TSV=$PR_LIST_TSV" >> $GITHUB_ENV
+      - name: Fetch remote tags
+        run: |
+          # Fetch remote tags instead of using `fetch-tags` option in `actions/checkout`
+          # see: https://github.com/actions/checkout/issues/1467
+          git fetch origin 'refs/tags/*:refs/tags/*'
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-tags: true
       - name: Set GITHUB_ENV
         run: |
           NEXT_RELEASE=${{ github.ref_name }}


### PR DESCRIPTION
## Description

#15 was unable to fix the bug where remote tags were not fetched.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/15729367864

Instead of using `fetch-tags: true` option in [actions/checkout](https://github.com/actions/checkout), use `git fetch` command directly.