### PR TITLE
Refine `Fetch remote tags` step in `Create Release` action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           # Fetch remote tags instead of using `fetch-tags` option in `actions/checkout`
           # see: https://github.com/actions/checkout/issues/1467
-          git fetch origin 'refs/tags/*:refs/tags/*'
+          git fetch --force origin 'refs/tags/*:refs/tags/*'
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

#16 did not resolve a problem with fetching the remote refs.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/15730393104

Added an option `--force` to `git fetch` command and override the local refs created by [actions/checkout](https://github.com/actions/checkout).