### PR TITLE
Fix and improve `Create Release` action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - name: Set GITHUB_ENV
         run: |
           NEXT_RELEASE=${{ github.ref_name }}
@@ -35,10 +37,6 @@ jobs:
           COMMIT_HASH_SHORT=$(echo $COMMIT_HASH | cut -c 1-7)
 
           PREV_RELEASE=$(gh release list --limit 1 --json tagName | jq -r '.[].tagName')
-          # Fetch remote tag instead of using `fetch-tags` option in `actions/checkout`
-          # see: https://github.com/actions/checkout/issues/1467
-          git fetch origin "refs/tags/${PREV_RELEASE}:refs/tags/${PREV_RELEASE}"
-
           MERGE_COMMITS=$(git log ${PREV_RELEASE}...${NEXT_RELEASE} --merges --oneline | awk '{print $1}' | xargs)
           if [ -n "$MERGE_COMMITS" ]; then
             PR_URL_PREFIX="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull"


### PR DESCRIPTION
## Description

Fixed an following issues in [Create Release](https://github.com/SafiePublic/safie-webrtc-ios-build/actions/workflows/create-release.yml) action.

- `WebRTC Version` to show only major
- PR list in `Deployment` section

<img width="500" src="https://github.com/user-attachments/assets/cce1bae2-fbcb-404b-b984-6fb1ccccc279">
