### PR TITLE
Fix a broken link to patch file in release notes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -61,7 +61,7 @@ jobs:
 
           ### Applied Patches
 
-          - [disable_audio_input_interface](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${WEBRTC_VERSION}/patches/disable_audio_input_interface.patch) 
+          - [disable_audio_input_interface](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${NEXT_RELEASE}/patches/disable_audio_input_interface.patch)
 
           ## Development
 


### PR DESCRIPTION
## Description

[Create Release](https://github.com/SafiePublic/safie-webrtc-ios-build/actions/workflows/create-release.yml) action generates a release note includes a link to patch file.

This link was incorrect and has been corrected.

Before fixed:
https://github.com/SafiePublic/safie-webrtc-ios-build/blob/135/patches/disable_audio_input_interface.patch

After fixed:
https://github.com/SafiePublic/safie-webrtc-ios-build/blob/135.3.0/patches/disable_audio_input_interface.patch
