### PR TITLE
Avoid `commit_position` becoming NaN

### DIFF
--- a/scripts/webrtc-build.mjs
+++ b/scripts/webrtc-build.mjs
@@ -195,7 +195,7 @@ const webrtc_commit_hash = (await $`git rev-parse HEAD`).stdout.trim()
 
 const git_log = await $`git log -n 1 --pretty=fuller`
 const regex =new RegExp(`Cr-Commit-Position: refs/branch-heads/${branch_head_number}@{#(?<commit_position>\\d+)}`)
-const commit_position = Number(regex.exec(git_log)?.groups?.commit_position)
+const commit_position = Number(regex.exec(git_log)?.groups?.commit_position) || 0
 
 cd('..')
 


### PR DESCRIPTION
## Description

Failed to detect `commit_position` in the build of WebRTC M136.

- #21 

In this case, set `commit_position` to 0.

## How to test

Ran the action and verified PR.

- https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/16931648990
- #23