### PR TITLE
Continuous build of released but unbuilt WebRTC versions

### DIFF
--- a/.github/workflows/build-and-pr.yml
+++ b/.github/workflows/build-and-pr.yml
@@ -1,5 +1,16 @@
 name: WebRTC Build and Create Pull Request
 on: 
+  workflow_call:
+    inputs:
+      webrtc_version:
+        description: 'WebRTC Version'
+        required: true
+        type: string
+      build_number:
+        description: 'Build Number'
+        required: false
+        type: string
+        default: '0'
   workflow_dispatch:
     inputs:
       webrtc_version:

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,29 @@
+name: Continuous WebRTC Build
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+jobs:
+  detect_next_version:
+    name: Detect Next WebRTC Build Version
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      WEBRTC_NEXT_VERSION: ${{ steps.detect_next_build_version.outputs.WEBRTC_NEXT_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Detect next build version
+        id: detect_next_build_version
+        run: |
+          WEBRTC_NEXT_VERSION=$(npx zx ./scripts/next-build-version.mjs)
+          echo "WEBRTC_NEXT_VERSION=$WEBRTC_NEXT_VERSION" >> $GITHUB_OUTPUT
+  kick_build_and_pr:
+    name: Kick Build and PR Workflow
+    needs: detect_next_version
+    if: ${{ needs.detect_next_version.outputs.WEBRTC_NEXT_VERSION != '' }}
+    uses: ./.github/workflows/build-and-pr.yml
+    with:
+      webrtc_version: ${{ needs.detect_next_version.outputs.WEBRTC_NEXT_VERSION }}

--- a/scripts/next-build-version.mjs
+++ b/scripts/next-build-version.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env zx
+
+// Fetch remote released versions
+const response_releases = await fetch(`https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=iOS`)
+if (!response_releases.ok) {
+  await $`echo '❗️ Failed to fetch releases' 1>&2`
+  process.exit(1)
+}
+
+const releases = await response_releases.json()
+const released_versions = [...new Set(releases.map((release) => release["milestone"]))]
+
+// Detect latest built WebRTC version
+
+await $`git fetch --all`
+const branches = await $`git for-each-ref --format='%(refname)' refs/remotes/origin`
+const tags = await $`git for-each-ref --format='%(refname)' refs/tags`
+const refs = [...branches.lines(), ...tags.lines()]
+
+let latest_built_version = null
+for (const ref of refs) {
+  const version = await $`git cat-file -p ${ref}:version.json | jq -r ".version.webrtc_version"`
+  latest_built_version = latest_built_version != null ? Math.max(latest_built_version, version) : version
+}
+if (latest_built_version == null) {
+  await $`echo '❗️ Failed to detect latest built version' 1>&2`
+  process.exit(1)
+}
+
+// Look for the next WebRTC build version
+
+const next_build_version = released_versions.reduce((acc, cur) => {
+  if (cur > latest_built_version) {
+    return acc != null ? Math.min(acc, cur) : cur
+  } else {
+    return acc
+  }
+}, null)
+
+if (next_build_version != null) {
+  echo`${next_build_version}`
+}


### PR DESCRIPTION
## Description

Currently, this repository provides a way to manually build a specified version of WebRTC.

This PR introduces a feature that automatically builds a new WebRTC version for each release.

Feature performs the following steps on a weekly basis.

1. Make a list of built WebRTC versions from the remote branch and tag list
1. Retrieve the released WebRTC versions via API
1. Check for WebRTC versions that are not yet build and have been released
1. Automatically build the minimum version from the list in  step 3 and create a PR

## How to test

Change the default branch and run manually.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/16981385496
