### PR TITLE
Update `disable_audio_input_interface.patch` for M137 compatibility

### DIFF
--- a/patches/disable_audio_input_interface.patch
+++ b/patches/disable_audio_input_interface.patch
@@ -1,14 +1,14 @@
 diff --git a/modules/audio_device/audio_device_impl.cc b/modules/audio_device/audio_device_impl.cc
-index 44cfabeddd..6b330f834e 100644
+index c63a478c5f..e85fac074e 100644
 --- a/modules/audio_device/audio_device_impl.cc
 +++ b/modules/audio_device/audio_device_impl.cc
-@@ -243,6 +243,7 @@ int32_t AudioDeviceModuleImpl::CreatePlatformSpecificObjects() {
-   if (audio_layer == kPlatformDefaultAudio) {
-     audio_device_.reset(new ios_adm::AudioDeviceIOS(
+@@ -241,6 +241,7 @@ int32_t AudioDeviceModuleImpl::CreatePlatformSpecificObjects(
+     audio_device_ = std::make_unique<ios_adm::AudioDeviceIOS>(
+         env,
          /*bypass_voice_processing=*/false,
 +        /*disable_audio_input=*/false,
          /*muted_speech_event_handler=*/nullptr,
-         /*render_error_handler=*/nullptr));
+         /*render_error_handler=*/nullptr);
      RTC_LOG(LS_INFO) << "iPhone Audio APIs will be utilized.";
 diff --git a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h
 index abfa679a1c..6037318d32 100644
@@ -26,10 +26,10 @@ index abfa679a1c..6037318d32 100644
   * ADM */
  - (instancetype)
 diff --git a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
-index 79afe271da..8f8e7f7cab 100644
+index 5df145e34a..d001664628 100644
 --- a/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
 +++ b/sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm
-@@ -58,13 +58,14 @@ @implementation RTC_OBJC_TYPE (RTCPeerConnectionFactory) {
+@@ -58,6 +58,7 @@ @implementation RTC_OBJC_TYPE (RTCPeerConnectionFactory) {
    std::unique_ptr<webrtc::Thread> _workerThread;
    std::unique_ptr<webrtc::Thread> _signalingThread;
    BOOL _hasStartedAecDump;
@@ -37,16 +37,18 @@ index 79afe271da..8f8e7f7cab 100644
  }
  
  @synthesize nativeFactory = _nativeFactory;
- 
- - (webrtc::scoped_refptr<webrtc::AudioDeviceModule>)audioDeviceModule {
- #if defined(WEBRTC_IOS)
--  return webrtc::CreateAudioDeviceModule();
-+  return webrtc::CreateAudioDeviceModule(false, _disableAudioInput);
- #else
-   return nullptr;
+@@ -74,7 +75,8 @@ - (instancetype)init {
+       [[RTC_OBJC_TYPE(RTCVideoDecoderFactoryH264) alloc] init]);
+   dependencies.env = webrtc::CreateEnvironment();
+ #ifdef WEBRTC_IOS
+-  dependencies.adm = webrtc::CreateAudioDeviceModule(*dependencies.env);
++  dependencies.adm = webrtc::CreateAudioDeviceModule(
++      *dependencies.env, false, _disableAudioInput);
  #endif
-@@ -84,6 +85,11 @@ - (instancetype)init {
-   return [self initWithMediaAndDependencies:std::move(dependencies)];
+   return [self initWithMediaAndDependencies:dependencies];
+ }
+@@ -89,6 +91,11 @@ - (instancetype)init {
+                           audioDevice:nil];
  }
  
 +- (instancetype)initWithDisableAudioInput:(BOOL)disableAudioInput {
@@ -58,60 +60,90 @@ index 79afe271da..8f8e7f7cab 100644
      initWithEncoderFactory:
          (nullable id<RTC_OBJC_TYPE(RTCVideoEncoderFactory)>)encoderFactory
 diff --git a/sdk/objc/native/api/audio_device_module.h b/sdk/objc/native/api/audio_device_module.h
-index 34f99e85c8..2264db8901 100644
+index 5a8944c674..3a80c39bfd 100644
 --- a/sdk/objc/native/api/audio_device_module.h
 +++ b/sdk/objc/native/api/audio_device_module.h
-@@ -24,7 +24,8 @@ namespace webrtc {
- // consequences for the audio path in the device. It is not advisable to use in
+@@ -27,11 +27,12 @@ namespace webrtc {
  // most scenarios.
- webrtc::scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
+ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
+     const Environment& env,
 -    bool bypass_voice_processing = false);
 +    bool bypass_voice_processing = false,
 +    bool disable_audio_input = false);
  
+ [[deprecated("Pass `env` explicitly instead of relying on the default")]]
+ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
+-    bool bypass_voice_processing = false);
++    bool bypass_voice_processing = false, bool disable_audio_input = false);
+ 
  // If `muted_speech_event_handler` is exist, audio unit will catch speech
  // activity while muted.
 diff --git a/sdk/objc/native/api/audio_device_module.mm b/sdk/objc/native/api/audio_device_module.mm
-index 898886b592..fd2787ae4b 100644
+index 8325179c94..99088a71c2 100644
 --- a/sdk/objc/native/api/audio_device_module.mm
 +++ b/sdk/objc/native/api/audio_device_module.mm
-@@ -18,11 +18,13 @@
+@@ -23,21 +23,25 @@
  namespace webrtc {
  
- webrtc::scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
--    bool bypass_voice_processing) {
+ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
+-    const Environment& env, bool bypass_voice_processing) {
++    const Environment& env,
 +    bool bypass_voice_processing,
 +    bool disable_audio_input) {
    RTC_DLOG(LS_INFO) << __FUNCTION__;
- #if defined(WEBRTC_IOS)
-   return webrtc::make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
+   return make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
+       env,
        bypass_voice_processing,
 +      disable_audio_input,
        /*muted_speech_event_handler=*/nullptr,
        /*error_handler=*/nullptr);
- #else
-@@ -48,7 +50,7 @@
+ }
+ 
+ scoped_refptr<AudioDeviceModule> CreateAudioDeviceModule(
+-    bool bypass_voice_processing) {
++    bool bypass_voice_processing, bool disable_audio_input) {
    RTC_DLOG(LS_INFO) << __FUNCTION__;
- #if defined(WEBRTC_IOS)
-   return webrtc::make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
--      bypass_voice_processing, muted_speech_event_handler, error_handler);
-+      bypass_voice_processing, false, muted_speech_event_handler, error_handler);
- #else
-   RTC_LOG(LS_ERROR)
-       << "current platform is not supported => this module will self destruct!";
+   return make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
+       CreateEnvironment(),
+       bypass_voice_processing,
++      disable_audio_input,
+       /*muted_speech_event_handler=*/nullptr,
+       /*error_handler=*/nullptr);
+ }
+@@ -49,7 +53,11 @@
+     bool bypass_voice_processing) {
+   RTC_DLOG(LS_INFO) << __FUNCTION__;
+   return make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
+-      env, bypass_voice_processing, muted_speech_event_handler, error_handler);
++      env,
++      bypass_voice_processing,
++      false,
++      muted_speech_event_handler,
++      error_handler);
+ }
+ 
+ scoped_refptr<AudioDeviceModule> CreateMutedDetectAudioDeviceModule(
+@@ -60,6 +68,7 @@
+   return make_ref_counted<ios_adm::AudioDeviceModuleIOS>(
+       CreateEnvironment(),
+       bypass_voice_processing,
++      false,
+       muted_speech_event_handler,
+       error_handler);
+ }
 diff --git a/sdk/objc/native/src/audio/audio_device_ios.h b/sdk/objc/native/src/audio/audio_device_ios.h
-index cc70ee7f2f..47b9cf5a70 100644
+index 7dcffb07d5..4fb81c8ee2 100644
 --- a/sdk/objc/native/src/audio/audio_device_ios.h
 +++ b/sdk/objc/native/src/audio/audio_device_ios.h
-@@ -57,6 +57,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
-  public:
+@@ -59,6 +59,7 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
    explicit AudioDeviceIOS(
+       const Environment& env,
        bool bypass_voice_processing,
 +      bool disable_audio_input,
        AudioDeviceModule::MutedSpeechEventHandler muted_speech_event_handler,
        AudioDeviceIOSRenderErrorHandler render_error_handler);
    ~AudioDeviceIOS() override;
-@@ -223,6 +224,9 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
+@@ -227,6 +228,9 @@ class AudioDeviceIOS : public AudioDeviceGeneric,
    // Determines whether voice processing should be enabled or disabled.
    const bool bypass_voice_processing_;
  
@@ -122,22 +154,23 @@ index cc70ee7f2f..47b9cf5a70 100644
    AudioDeviceModule::MutedSpeechEventHandler muted_speech_event_handler_;
  
 diff --git a/sdk/objc/native/src/audio/audio_device_ios.mm b/sdk/objc/native/src/audio/audio_device_ios.mm
-index 25c1e02022..94c5278051 100644
+index 53dec77c75..0698f9ebcf 100644
 --- a/sdk/objc/native/src/audio/audio_device_ios.mm
 +++ b/sdk/objc/native/src/audio/audio_device_ios.mm
-@@ -97,9 +97,11 @@ static void LogDeviceInfo() {
- 
+@@ -98,10 +98,12 @@ static void LogDeviceInfo() {
  AudioDeviceIOS::AudioDeviceIOS(
+     const Environment& env,
      bool bypass_voice_processing,
 +    bool disable_audio_input,
      AudioDeviceModule::MutedSpeechEventHandler muted_speech_event_handler,
      AudioDeviceIOSRenderErrorHandler render_error_handler)
-     : bypass_voice_processing_(bypass_voice_processing),
+     : env_(env),
+       bypass_voice_processing_(bypass_voice_processing),
 +      disable_audio_input_(disable_audio_input),
        muted_speech_event_handler_(muted_speech_event_handler),
        render_error_handler_(render_error_handler),
        disregard_next_render_error_(false),
-@@ -820,8 +822,10 @@ static void LogDeviceInfo() {
+@@ -822,8 +824,10 @@ static void LogDeviceInfo() {
      return false;
    }
    BOOL detect_mute_speech_ = (muted_speech_event_handler_ != 0);
@@ -151,55 +184,50 @@ index 25c1e02022..94c5278051 100644
      audio_unit_.reset();
      return false;
 diff --git a/sdk/objc/native/src/audio/audio_device_module_ios.h b/sdk/objc/native/src/audio/audio_device_module_ios.h
-index 394e1ff9bd..6dcaf174f9 100644
+index 5ff50621b3..cbde002d46 100644
 --- a/sdk/objc/native/src/audio/audio_device_module_ios.h
 +++ b/sdk/objc/native/src/audio/audio_device_module_ios.h
 @@ -32,6 +32,7 @@ class AudioDeviceModuleIOS : public AudioDeviceModule {
- 
    explicit AudioDeviceModuleIOS(
+       const Environment& env,
        bool bypass_voice_processing,
 +      bool disable_audio_input,
        MutedSpeechEventHandler muted_speech_event_handler,
        ADMErrorHandler error_handler);
    ~AudioDeviceModuleIOS() override;
-@@ -138,6 +139,7 @@ class AudioDeviceModuleIOS : public AudioDeviceModule {
-  private:
-   void ReportError(ADMError error) const;
+@@ -140,6 +141,7 @@ class AudioDeviceModuleIOS : public AudioDeviceModule {
+ 
+   const Environment env_;
    const bool bypass_voice_processing_;
 +  const bool disable_audio_input_;
    MutedSpeechEventHandler muted_speech_event_handler_;
    ADMErrorHandler error_handler_;
    bool initialized_ = false;
 diff --git a/sdk/objc/native/src/audio/audio_device_module_ios.mm b/sdk/objc/native/src/audio/audio_device_module_ios.mm
-index 3b338f2399..d080447101 100644
+index 7420d05ebd..8a77d7fcac 100644
 --- a/sdk/objc/native/src/audio/audio_device_module_ios.mm
 +++ b/sdk/objc/native/src/audio/audio_device_module_ios.mm
-@@ -43,9 +43,11 @@
- 
+@@ -46,10 +46,12 @@
  AudioDeviceModuleIOS::AudioDeviceModuleIOS(
+     const Environment& env,
      bool bypass_voice_processing,
 +    bool disable_audio_input,
      MutedSpeechEventHandler muted_speech_event_handler,
      ADMErrorHandler error_handler)
-     : bypass_voice_processing_(bypass_voice_processing),
+     : env_(env),
+       bypass_voice_processing_(bypass_voice_processing),
 +      disable_audio_input_(disable_audio_input),
        muted_speech_event_handler_(muted_speech_event_handler),
-       error_handler_(error_handler),
-       task_queue_factory_(CreateDefaultTaskQueueFactory()) {
-@@ -89,8 +91,11 @@
-   };
-   audio_device_buffer_.reset(
-       new webrtc::AudioDeviceBuffer(task_queue_factory_.get()));
--  audio_device_.reset(new ios_adm::AudioDeviceIOS(
--      bypass_voice_processing_, muted_speech_event_handler_, error_handler));
-+  audio_device_.reset(
-+      new ios_adm::AudioDeviceIOS(bypass_voice_processing_,
-+                                  disable_audio_input_,
-+                                  muted_speech_event_handler_,
-+                                  error_handler));
+       error_handler_(error_handler) {
+   RTC_LOG(LS_INFO) << "current platform is IOS";
+@@ -95,6 +97,7 @@
+   audio_device_ =
+       std::make_unique<ios_adm::AudioDeviceIOS>(env_,
+                                                 bypass_voice_processing_,
++                                                disable_audio_input_,
+                                                 muted_speech_event_handler_,
+                                                 error_handler);
    RTC_CHECK(audio_device_);
- 
-   this->AttachAudioBuffer();
 diff --git a/sdk/objc/native/src/audio/voice_processing_audio_unit.h b/sdk/objc/native/src/audio/voice_processing_audio_unit.h
 index 99586a94ed..b2dab417e4 100644
 --- a/sdk/objc/native/src/audio/voice_processing_audio_unit.h


### PR DESCRIPTION
## Description

Applying the patch `disable_audio_input_interface.patch` to WebRTC M137 will be failed.

```
⏳ Applying patches...
Error: 
    at file:///Users/runner/work/safie-webrtc-ios-build/safie-webrtc-ios-build/scripts/webrtc-build.mjs:89:10
    exit code: 1
    details: 
patching file 'modules/audio_device/audio_device_impl.cc'
patching file 'sdk/objc/api/peerconnection/RTCPeerConnectionFactory.h'
patching file 'sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm'
1 out of 2 hunks failed--saving rejects to 'sdk/objc/api/peerconnection/RTCPeerConnectionFactory.mm.rej'
patching file 'sdk/objc/native/api/audio_device_module.h'
1 out of 1 hunks failed--saving rejects to 'sdk/objc/native/api/audio_device_module.h.rej'
patching file 'sdk/objc/native/api/audio_device_module.mm'
2 out of 2 hunks failed--saving rejects to 'sdk/objc/native/api/audio_device_module.mm.rej'
patching file 'sdk/objc/native/src/audio/audio_device_ios.h'
patching file 'sdk/objc/native/src/audio/audio_device_ios.mm'
1 out of 2 hunks failed--saving rejects to 'sdk/objc/native/src/audio/audio_device_ios.mm.rej'
patching file 'sdk/objc/native/src/audio/audio_device_module_ios.h'
patching file 'sdk/objc/native/src/audio/audio_device_module_ios.mm'
2 out of 2 hunks failed--saving rejects to 'sdk/objc/native/src/audio/audio_device_module_ios.mm.rej'
patching file 'sdk/objc/native/src/audio/voice_processing_audio_unit.h'
patching file 'sdk/objc/native/src/audio/voice_processing_audio_unit.mm'
Error: Process completed with exit code 1.
```

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/16981385496/job/48141822377

Fixed this patch file based on the WebRTC M138 code.

## How to test

Ran a test action using `update-patch-for-m138` branch and confirmed that the build completed successfully.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/16983520666
