### PR TITLE
Bump up macOS and Xcode version

### DIFF
--- a/.github/workflows/build-and-pr.yml
+++ b/.github/workflows/build-and-pr.yml
@@ -25,12 +25,15 @@ on:
 jobs:
   build_and_pr:
     name: Build and Pull Request
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
     permissions:
       contents: write
       pull-requests: write
     steps:
+      - name: Set Xcode version
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.4.1.app
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -14,11 +14,14 @@ on:
 jobs:
   build_and_upload:
     name: Build and Upload
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
     permissions:
       contents: read
     steps:
+      - name: Set Xcode version
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.4.1.app
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Description

In WebRTC development, Xcode version has been updated to 26.0.

https://chromium-review.googlesource.com/c/chromium/src/+/6950738

This change is included in WebRTC version M142, and with the current configuration, this version cannot be built.

Fixed this issue with following updates:

- Updated the GitHub Actions runner image to [macos-26](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md)
- Fixed the Xcode version used in the build environment to `26.4.1`

## How to test

Verified in a test action using this branch and M142 source code.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/25034120062