### PR TITLE
Bump up tracking `depot_tools` version

### DIFF
--- a/scripts/webrtc-build.mjs
+++ b/scripts/webrtc-build.mjs
@@ -4,6 +4,11 @@
 // see: https://chromium.googlesource.com/chromium/tools/depot_tools
 $.env.DEPOT_TOOLS_UPDATE = 0
 
+// Ensure depot_tools bundled python (python-bin/python3) is bootstrapped.
+// gn (post 2025-05-01) requires this. ensure_bootstrap does not modify the
+// depot_tools git checkout, so it is compatible with our SHA-pinned submodule.
+await $`${path.join(__dirname, '..', 'depot_tools', 'ensure_bootstrap')}`
+
 const cwd = await $`echo -n $(pwd)`
 
 // Parse Arguments


### PR DESCRIPTION
## Description

Bump up `depot_tools` version introduced by git submodule.

Due to changes in `depot_tools` behaviors, make minor fixes to the build script.

## How to test

I have confirmed that the test build using the `bump-up-depot-tools` branch completed successfully.

https://github.com/SafiePublic/safie-webrtc-ios-build/actions/runs/25649688575